### PR TITLE
[client] Fix narrowing issues with win:shrinkOnUpscale param

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -234,12 +234,12 @@ void core_updatePositionInfo(void)
       if (g_state.windowW > srcW)
       {
         force = true;
-        g_state.dstRect.w = srcW;
+        g_state.dstRect.w = (int) (srcW + 0.5);
       }
       if (g_state.windowH > srcH)
       {
         force = true;
-        g_state.dstRect.h = srcH;
+        g_state.dstRect.h = (int) (srcH + 0.5);
       }
     }
 


### PR DESCRIPTION
Conversion from the float values srcW/srcH to the int values for the client window dimensions would sometimes round down, causing the client to scale instead of matching the host's resolution.